### PR TITLE
Add theme toggle and widen split diff

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,16 +1,75 @@
 <script setup lang="ts">
-import Diff from './components/Diff.vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import Diff from './components/Diff.vue';
+
+type ThemePreference = 'system' | 'light' | 'dark';
+
+const themePreference = ref<ThemePreference>('system');
+const systemPrefersDark = ref(false);
+let mediaQuery: MediaQueryList | null = null;
+
+const effectiveTheme = computed(() =>
+  themePreference.value === 'system'
+    ? (systemPrefersDark.value ? 'dark' : 'light')
+    : themePreference.value,
+);
+
+const applyTheme = () => {
+  const theme = effectiveTheme.value;
+  const root = document.documentElement;
+  root.dataset.theme = theme;
+  root.style.colorScheme = theme;
+};
+
+const handleSystemChange = (event: MediaQueryListEvent) => {
+  systemPrefersDark.value = event.matches;
+  if (themePreference.value === 'system') {
+    applyTheme();
+  }
+};
+
+onMounted(() => {
+  mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  systemPrefersDark.value = mediaQuery.matches;
+  mediaQuery.addEventListener('change', handleSystemChange);
+  applyTheme();
+});
+
+onBeforeUnmount(() => {
+  mediaQuery?.removeEventListener('change', handleSystemChange);
+});
+
+watch(themePreference, applyTheme);
 </script>
 
 <template>
-  <a href="https://github.com/CurtisTarr/diff" target="_blank">
-    <img src="./assets/github-mark-white.svg" alt="GitHub logo" class="github-logo"/>
-  </a>
+  <header class="top-bar">
+    <a href="https://github.com/CurtisTarr/diff" target="_blank" aria-label="Project source code">
+      <img src="./assets/github-mark-white.svg" alt="GitHub logo" class="github-logo" />
+    </a>
+
+    <label class="theme-toggle" for="theme">
+      Theme
+      <select id="theme" v-model="themePreference" aria-label="Select color theme preference">
+        <option value="system">System</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </select>
+    </label>
+  </header>
+
   <h2>Diff</h2>
   <Diff />
 </template>
 
 <style scoped>
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
 .github-logo {
   position: fixed;
   top: 14px;
@@ -18,9 +77,35 @@ import Diff from './components/Diff.vue'
   width: 32px;
   height: 32px;
   opacity: 0.8;
-  transition: transform .15s ease, opacity .2s ease, filter .2s ease;
+  transition: transform 0.15s ease, opacity 0.2s ease, filter 0.2s ease;
 }
-.github-logo:hover { transform: scale(1.06); opacity: 1; filter: drop-shadow(0 6px 16px rgba(0,0,0,.4)); }
 
-h2 { margin: 12px 0 18px; }
+.github-logo:hover {
+  transform: scale(1.06);
+  opacity: 1;
+  filter: drop-shadow(0 6px 16px rgba(0, 0, 0, 0.4));
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0.6rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text);
+}
+
+.theme-toggle select {
+  padding: 0.3rem 0.5rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-1, var(--surface));
+  color: var(--text);
+}
+
+h2 {
+  margin: 12px 0 18px;
+}
 </style>

--- a/src/components/Diff.vue
+++ b/src/components/Diff.vue
@@ -52,7 +52,6 @@
 import { defineComponent } from 'vue';
 import { createTwoFilesPatch, diffLines, Change, PatchOptions } from 'diff';
 import hljs from 'highlight.js';
-import 'highlight.js/styles/github-dark-dimmed.css';
 
 type SplitRow = {
   leftText: string;
@@ -202,6 +201,7 @@ export default defineComponent({
 .diff-output {
   padding: 0; /* pre has its own padding from global styles */
   text-align: left;
+  max-width: 90vw;
 }
 .diff-output :deep(pre) {
   max-height: 50vh;
@@ -211,11 +211,12 @@ export default defineComponent({
   display: grid;
   grid-template-rows: auto 1fr;
   gap: var(--space-2);
+  overflow-x: auto;
 }
 
 .split-header {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: var(--space-1);
   padding: 0 var(--space-3);
   font-weight: 600;
@@ -224,9 +225,10 @@ export default defineComponent({
 
 .split-body {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: var(--space-1);
   align-items: start;
+  width: 100%;
 }
 
 .split-row {

--- a/src/style.css
+++ b/src/style.css
@@ -3,18 +3,6 @@
   --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
   --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 
-  /* Colors */
-  --bg: #0f172a;             /* slate-900 */
-  --bg-elev: #111827;        /* gray-900 */
-  --surface: #1f2937;        /* gray-800 */
-  --text: #e5e7eb;           /* gray-200 */
-  --muted: #9ca3af;          /* gray-400 */
-  --primary: #6366f1;        /* indigo-500 */
-  --primary-600: #5457e0;
-  --ring: rgba(99, 102, 241, 0.35);
-  --border: rgba(148, 163, 184, 0.2);
-  --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
-
   /* Layout */
   --radius: 12px;
   --radius-sm: 8px;
@@ -25,20 +13,67 @@
   --space-4: 16px;
   --space-6: 24px;
   --space-8: 32px;
-  --container: 1100px;
+  --container: min(1400px, 90vw);
 
-  color-scheme: dark;
+  /* Default colors (overridden by data-theme) */
+  --bg: #0f172a;
+  --bg-elev: #111827;
+  --surface: #1f2937;
+  --surface-1: #161f2f;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --primary: #6366f1;
+  --primary-600: #5457e0;
+  --ring: rgba(99, 102, 241, 0.35);
+  --border: rgba(148, 163, 184, 0.2);
+  --border-subtle: rgba(148, 163, 184, 0.3);
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+:root[data-theme="dark"] {
+  --bg: #0f172a;             /* slate-900 */
+  --bg-elev: #111827;        /* gray-900 */
+  --surface: #1f2937;        /* gray-800 */
+  --surface-1: #161f2f;
+  --text: #e5e7eb;           /* gray-200 */
+  --muted: #9ca3af;          /* gray-400 */
+  --primary: #6366f1;        /* indigo-500 */
+  --primary-600: #5457e0;
+  --ring: rgba(99, 102, 241, 0.35);
+  --border: rgba(148, 163, 184, 0.2);
+  --border-subtle: rgba(148, 163, 184, 0.3);
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+
+  color-scheme: dark;
+}
+
+:root[data-theme="light"] {
+  --bg: #f8fafc;             /* slate-50 */
+  --bg-elev: #ffffff;
+  --surface: #e2e8f0;        /* slate-200 */
+  --surface-1: #f1f5f9;
+  --text: #0f172a;           /* slate-900 */
+  --muted: #475569;          /* slate-600 */
+  --primary: #6366f1;        /* indigo-500 */
+  --primary-600: #4f46e5;
+  --ring: rgba(99, 102, 241, 0.25);
+  --border: rgba(15, 23, 42, 0.15);
+  --border-subtle: rgba(15, 23, 42, 0.2);
+  --shadow: 0 12px 28px rgba(15, 23, 42, 0.14);
+
+  color-scheme: light;
+}
+
 /* Modern CSS reset (minimal) */
 *, *::before, *::after { box-sizing: border-box; }
 * { margin: 0; }
 img, svg, video { display: block; max-width: 100%; }
-button, input, textarea { font: inherit; color: inherit; }
+button, input, textarea, select { font: inherit; color: inherit; }
 
 html, body { height: 100%; }
 
@@ -53,6 +88,13 @@ body {
   line-height: 1.6;
   display: flex;
   align-items: flex-start;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+:root[data-theme="light"] body {
+  background: radial-gradient(1200px 600px at 10% -10%, rgba(99,102,241,0.14), transparent),
+              radial-gradient(1000px 500px at 110% 10%, rgba(16,185,129,0.12), transparent),
+              var(--bg);
 }
 
 #app {
@@ -90,7 +132,7 @@ textarea, input[type="text"], input[type="search"] {
   outline: none;
   transition: border-color .2s ease, box-shadow .2s ease, transform .05s ease;
 }
-textarea:focus, input:focus {
+textarea:focus, input:focus, select:focus {
   border-color: var(--primary);
   box-shadow: 0 0 0 4px var(--ring);
 }
@@ -116,4 +158,24 @@ pre {
   border-radius: var(--radius);
   padding: var(--space-6);
   overflow: auto;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+.diff-output :deep(.hljs) {
+  background: var(--surface);
+  color: var(--text);
+}
+
+.diff-output :deep(.hljs-addition) {
+  background-color: rgba(46, 160, 67, 0.14);
+  color: inherit;
+}
+
+.diff-output :deep(.hljs-deletion) {
+  background-color: rgba(248, 81, 73, 0.14);
+  color: inherit;
+}
+
+.diff-output :deep(.hljs-meta) {
+  color: var(--muted);
 }


### PR DESCRIPTION
## Summary
- add a theme selector that defaults to the system preference and updates the global color variables
- introduce light and dark theme palettes so the UI and highlighted diffs adapt to the chosen mode
- widen the layout and split diff view to use up to 90% of the viewport while containing overflow

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f0d9ac1e4832cb64650c68fc91c9a)