### PR TITLE
Add line numbers and improve diff styling

### DIFF
--- a/src/components/Diff.vue
+++ b/src/components/Diff.vue
@@ -331,6 +331,23 @@ export default defineComponent({
   color: var(--muted);
   user-select: none;
   min-width: 2.5rem;
+  border-right: 1px solid var(--border);
+}
+
+.line-num.added {
+  background-color: var(--diff-added-gutter);
+}
+
+.line-num.removed {
+  background-color: var(--diff-removed-gutter);
+}
+
+.line-num.unchanged {
+  background-color: var(--bg-elev);
+}
+
+.line-num.empty {
+  background-color: transparent;
 }
 
 .cell {

--- a/src/components/Diff.vue
+++ b/src/components/Diff.vue
@@ -28,12 +28,6 @@
       <pre v-if="displayMode === 'combined'" v-html="highlightedDifferences"></pre>
 
       <div v-else class="split-diff" aria-label="Split diff view">
-        <div class="split-header">
-          <div></div>
-          <div>Left</div>
-          <div></div>
-          <div>Right</div>
-        </div>
         <div class="split-body" role="table" aria-label="Side by side diff">
           <div
             v-for="(row, index) in splitRows"
@@ -293,22 +287,17 @@ export default defineComponent({
 }
 .diff-output :deep(pre) {
   max-height: 50vh;
+  background: transparent;
+  border: none;
+  padding: var(--space-6);
 }
 
 .split-diff {
   display: grid;
   grid-template-rows: auto 1fr;
-  gap: var(--space-2);
   overflow-x: auto;
-}
-
-.split-header {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto minmax(0, 1fr);
-  gap: 0 var(--space-1);
-  padding: 0 var(--space-3);
-  font-weight: 600;
-  color: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
 }
 
 .split-body {
@@ -317,6 +306,7 @@ export default defineComponent({
   gap: 0;
   align-items: start;
   width: 100%;
+  padding: var(--space-6);
 }
 
 .split-row {
@@ -343,7 +333,7 @@ export default defineComponent({
 }
 
 .line-num.unchanged {
-  background-color: var(--bg-elev);
+  background-color: transparent;
 }
 
 .line-num.empty {
@@ -366,7 +356,7 @@ export default defineComponent({
 }
 
 .cell.unchanged {
-  background-color: var(--diff-neutral);
+  background-color: transparent;
 }
 
 .cell.empty {
@@ -374,14 +364,8 @@ export default defineComponent({
 }
 
 @media (max-width: 720px) {
-  .split-body,
-  .split-header {
-    grid-template-columns: auto 1fr;
-  }
-
-  .split-row {
-    display: grid;
-    grid-template-columns: auto 1fr;
+  .split-body {
+    grid-template-columns: auto 1fr auto 1fr;
   }
 }
 </style>

--- a/src/style.css
+++ b/src/style.css
@@ -203,31 +203,48 @@ pre {
   transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
-.diff-output :deep(.hljs) {
+.diff-output .hljs {
   background: var(--surface);
   color: var(--text);
 }
 
-.diff-output :deep(.hljs-addition),
-.diff-output :deep(.hljs-deletion),
-.diff-output :deep(.hljs-meta) {
-  display: block;
-  padding: 0.2rem 0.5rem;
-  margin: 0 -0.5rem;
-  border-radius: var(--radius-sm);
+.diff-output .diff-line {
+  display: flex;
+  line-height: 1.5;
 }
 
-.diff-output :deep(.hljs-addition) {
-  background-color: var(--diff-added);
-  color: inherit;
-}
-
-.diff-output :deep(.hljs-deletion) {
-  background-color: var(--diff-removed);
-  color: inherit;
-}
-
-.diff-output :deep(.hljs-meta) {
+.diff-output .diff-line > .line-num {
+  min-width: 2.5rem;
+  padding: 0 0.5rem;
+  text-align: right;
   color: var(--muted);
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.diff-output .diff-line > .line-content {
+  flex: 1;
+  padding: 0 0.5rem;
+}
+
+.diff-output .hljs-addition,
+.diff-output .hljs-deletion,
+.diff-output .hljs-meta {
+  display: inline;
+}
+
+.diff-output .line-content:has(.hljs-addition) {
+  background-color: var(--diff-added);
+}
+
+.diff-output .line-content:has(.hljs-deletion) {
+  background-color: var(--diff-removed);
+}
+
+.diff-output .line-content:has(.hljs-meta) {
   background-color: var(--diff-neutral);
+}
+
+.diff-output .hljs-meta {
+  color: var(--muted);
 }

--- a/src/style.css
+++ b/src/style.css
@@ -33,6 +33,8 @@
   --diff-added: rgba(34, 197, 94, 0.18);
   --diff-removed: rgba(239, 68, 68, 0.2);
   --diff-neutral: rgba(110, 118, 129, 0.12);
+  --diff-added-gutter: rgba(34, 197, 94, 0.35);
+  --diff-removed-gutter: rgba(239, 68, 68, 0.35);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -74,6 +76,8 @@
   --diff-added: rgba(34, 197, 94, 0.32);
   --diff-removed: rgba(239, 68, 68, 0.32);
   --diff-neutral: rgba(100, 116, 139, 0.2);
+  --diff-added-gutter: rgba(34, 197, 94, 0.5);
+  --diff-removed-gutter: rgba(239, 68, 68, 0.5);
 
   color-scheme: light;
 }
@@ -95,6 +99,8 @@
   --diff-added: rgba(52, 211, 153, 0.25);    /* Emerald green */
   --diff-removed: rgba(248, 113, 113, 0.25); /* Red coral */
   --diff-neutral: rgba(100, 150, 170, 0.15); /* Ocean gray */
+  --diff-added-gutter: rgba(52, 211, 153, 0.4);
+  --diff-removed-gutter: rgba(248, 113, 113, 0.4);
 
   color-scheme: dark;
 }
@@ -222,9 +228,23 @@ pre {
   flex-shrink: 0;
 }
 
+.diff-output .diff-line > .line-num:last-of-type {
+  border-right: 1px solid var(--border);
+}
+
+.diff-output .line-content:has(.hljs-addition) ~ .line-num,
+.diff-output .diff-line:has(.hljs-addition) > .line-num {
+  background-color: var(--diff-added-gutter);
+}
+
+.diff-output .line-content:has(.hljs-deletion) ~ .line-num,
+.diff-output .diff-line:has(.hljs-deletion) > .line-num {
+  background-color: var(--diff-removed-gutter);
+}
+
 .diff-output .diff-line > .line-content {
   flex: 1;
-  padding: 0 0.5rem;
+  padding: 0 0.75rem;
 }
 
 .diff-output .hljs-addition,

--- a/src/style.css
+++ b/src/style.css
@@ -210,7 +210,7 @@ pre {
 }
 
 .diff-output .hljs {
-  background: var(--surface);
+  background: transparent;
   color: var(--text);
 }
 
@@ -262,7 +262,7 @@ pre {
 }
 
 .diff-output .line-content:has(.hljs-meta) {
-  background-color: var(--diff-neutral);
+  background-color: transparent;
 }
 
 .diff-output .hljs-meta {


### PR DESCRIPTION
## Summary
- Add line numbers to both combined and split diff views
- Fix combined diff colors by removing invalid `:deep()` from global CSS
- Add colored gutters matching the diff type (green for added, red for removed)
- Align styling between combined and split views for visual consistency
- Remove gaps between diff lines for GitHub-like appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)